### PR TITLE
Fix YAML key completions leaking across task boundaries

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -191,7 +191,6 @@ connection.onInitialize((params: InitializeParams) => {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       completionProvider: {
         resolveProvider: true,
-        triggerCharacters: [" ", "[", ",", ":", "\n", "/"],
       },
       diagnosticProvider: {
         interFileDependencies: false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1701,6 +1701,9 @@ function getExistingSiblingKeys(
           : 0;
       })();
 
+  // Check if the current line itself starts a new list item
+  const currentHasDash = /^\s*-\s/.test(currentLine);
+
   const keys = new Set<string>();
 
   // Scan backward and forward from the cursor to find sibling keys
@@ -1718,11 +1721,37 @@ function getExistingSiblingKeys(
       const match = line.match(/^(\s*)(-\s+)?([a-zA-Z0-9_-]+)\s*:/);
       if (!match || !match[3]) continue;
 
+      const hasDash = !!match[2];
       const lineEffectiveIndent =
         (match[1] ?? "").length + (match[2] ?? "").length;
 
       // Same indent level — sibling key
       if (lineEffectiveIndent === currentEffectiveIndent) {
+        // When the cursor is on a dash line (start of a new list item),
+        // everything backward belongs to a previous item — stop scanning.
+        // Forward non-dash lines are properties of this item (siblings).
+        if (currentHasDash) {
+          if (dir === -1) {
+            break;
+          }
+          if (hasDash) {
+            break;
+          }
+          keys.add(match[3]);
+          continue;
+        }
+
+        // When the cursor is NOT on a dash line, a dash at the same
+        // effective indent marks a list item boundary:
+        //   backward: include the dash line's key (it starts this item)
+        //     then stop — anything further belongs to a previous item.
+        //   forward: a dash starts a new item — stop before including it.
+        if (hasDash) {
+          if (dir === -1) {
+            keys.add(match[3]);
+          }
+          break;
+        }
         keys.add(match[3]);
         continue;
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1584,6 +1584,9 @@ function buildKeyCompletionMap(): Map<string, string[]> {
     // Skip wildcard entries like "*.value" or "*.cache-key"
     if (childKey === "*") continue;
 
+    // Skip internal keys that shouldn't be suggested to users
+    if (childKey === "bootstrapping") continue;
+
     if (!map.has(parent)) {
       map.set(parent, []);
     }

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -1009,6 +1009,49 @@ tasks:
       expect(labels).toContain("cache");
     });
 
+    it("does not leak sibling keys across task boundaries", async () => {
+      const yamlContent = `tasks:
+  - key: first-task
+    run: echo first
+    filter:
+      workspace: "src/**"
+  - key: second-task
+    run: echo second
+    `;
+
+      const filePath = await createTestFile(
+        testEnv.mintDir,
+        "cross-task.yml",
+        yamlContent
+      );
+
+      const textDocument = {
+        uri: `file://${filePath}`,
+        languageId: "yaml",
+        version: 1,
+        text: yamlContent,
+      };
+
+      server.sendNotification("textDocument/didOpen", { textDocument });
+
+      const completions = await server.sendRequest<CompletionItem[]>(
+        "textDocument/completion",
+        {
+          textDocument: { uri: textDocument.uri },
+          position: Position.create(8, 4),
+        }
+      );
+
+      const labels = completions.map((c) => c.label);
+      // key and run are in the current task — should be excluded
+      expect(labels).not.toContain("key");
+      expect(labels).not.toContain("run");
+      // filter is only in the previous task — should still be offered
+      expect(labels).toContain("filter");
+      expect(labels).toContain("after");
+      expect(labels).toContain("call");
+    });
+
     it("provides completions with documentation from keyDescriptions", async () => {
       const yamlContent = `tasks:
   - key: build

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -51,7 +51,6 @@ describe("LSP Server Lifecycle and Configuration", () => {
       );
       expect(result.capabilities.completionProvider).toEqual({
         resolveProvider: true,
-        triggerCharacters: [" ", "[", ",", ":", "\n", "/"],
       });
       expect(result.capabilities.diagnosticProvider).toEqual({
         interFileDependencies: false,


### PR DESCRIPTION
## Summary
- **Fix cross-task key completion leaking**: `getExistingSiblingKeys` scanned by indent level only, treating keys from other tasks as siblings of the current task. This caused keys like `key` and `filter` to be excluded from completions whenever any other task in the file had them. Now respects list item boundaries (`- ` prefix lines) so each task's completion list is scoped to its own block.
- **Exclude `bootstrapping` from completions**: Internal key that shouldn't be suggested to users.
- **Remove completion `triggerCharacters`**: The full set of trigger characters (`" "`, `[`, `,`, `:`, `\n`, `/`) caused completion popups to appear too aggressively. Completions still appear via VSCode's `quickSuggestions` as the user types word characters, and via explicit Ctrl+Space.

## Test plan
- [x] Added integration test verifying keys from other tasks don't leak into the current task's completions
- [x] All 118 tests pass
- [x] Verified in VSCode that `key` and `filter` appear correctly in completions
- [x] Verified completion popups no longer appear aggressively on space/newline/colon