### PR TITLE
Refactor key-descriptions as single source of truth with CI check

### DIFF
--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -59,6 +59,16 @@ tasks:
       test-results:
         - path: test-results.json
 
+  - key: check-key-descriptions
+    use: npm-install
+    run: npm run check-key-descriptions
+    filter:
+      - node_modules
+      - src/key-descriptions.ts
+      - scripts/compare-parser-keys.ts
+      - support/parser.js
+      - package.json
+
   - key: bundle
     call: ${{ run.dir }}/build.yml
     init:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "c8": "^10.1.3",
         "esbuild": "^0.27.3",
         "tmp-promise": "^3.0.3",
+        "tsx": "^4.21.0",
         "typescript": "^5.0.0",
         "vitest": "^1.0.0",
         "vscode-languageserver-protocol": "^3.17.5",
@@ -1660,6 +1661,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2286,6 +2300,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.44.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.2.tgz",
@@ -2563,6 +2587,26 @@
       "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-detect": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "bundle": "npm run compile && esbuild out/server.js --bundle --platform=node --target=node18 --outfile=dist/server.js --minify",
     "watch": "npm run compile -- -w",
     "test": "npm run compile && vitest run --reporter=default --reporter=json --outputFile=test-results.json",
-    "test:coverage": "npm run compile && NODE_V8_COVERAGE=coverage vitest run --reporter=default --reporter=json --outputFile=test-results.json && NODE_V8_COVERAGE=coverage npx c8 report --temp-directory=coverage --reporter=text --reporter=html --reporter=json"
+    "test:coverage": "npm run compile && NODE_V8_COVERAGE=coverage vitest run --reporter=default --reporter=json --outputFile=test-results.json && NODE_V8_COVERAGE=coverage npx c8 report --temp-directory=coverage --reporter=text --reporter=html --reporter=json",
+    "check-key-descriptions": "npx tsx scripts/compare-parser-keys.ts"
   },
   "dependencies": {
     "vscode-languageserver": "^8.1.0",
@@ -27,6 +28,7 @@
     "c8": "^10.1.3",
     "esbuild": "^0.27.3",
     "tmp-promise": "^3.0.3",
+    "tsx": "^4.21.0",
     "typescript": "^5.0.0",
     "vitest": "^1.0.0",
     "vscode-languageserver-protocol": "^3.17.5",

--- a/scripts/compare-parser-keys.ts
+++ b/scripts/compare-parser-keys.ts
@@ -1,0 +1,385 @@
+/**
+ * CI check: ensures every parser-accepted key is accounted for in key-descriptions.ts.
+ *
+ * Extracts accepted keys directly from parser.js by finding all parseObject()
+ * call sites and pulling the key names from their object literal arguments.
+ * No hardcoded key lists — when parser.js changes, this script automatically
+ * picks up the new keys.
+ *
+ * Usage: npx tsx scripts/compare-parser-keys.ts
+ * Exit 0 = all keys accounted for, Exit 1 = gaps found.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import {
+  keyDescriptions,
+  isKeyAutocomplete,
+  isKeyDocumented,
+} from "../src/key-descriptions.js";
+
+// --- Step 1: Extract key sets from parseObject() calls in parser.js ---
+
+const parserSource = fs.readFileSync(
+  path.join(__dirname, "..", "support", "parser.js"),
+  "utf-8",
+);
+
+/**
+ * Starting from an opening brace at `start`, find the matching close brace
+ * using a depth counter. Returns the index of the closing brace.
+ */
+function findMatchingBrace(source: string, start: number): number {
+  let depth = 0;
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+    // Skip string literals to avoid counting braces inside strings
+    else if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      i++;
+      while (i < source.length && source[i] !== quote) {
+        if (source[i] === "\\") i++; // skip escaped chars
+        i++;
+      }
+    }
+  }
+  return -1;
+}
+
+/**
+ * Extract the top-level keys from a JS object literal string.
+ * Finds key patterns like `"key-name":` or `key:` at brace depth 0.
+ */
+function extractObjectKeys(objectLiteral: string): string[] {
+  const keys: string[] = [];
+  let depth = 0;
+  let i = 0;
+
+  while (i < objectLiteral.length) {
+    const ch = objectLiteral[i]!;
+
+    if (ch === "{" || ch === "(" || ch === "[") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === "}" || ch === ")" || ch === "]") {
+      depth--;
+      i++;
+      continue;
+    }
+
+    // Skip string literals
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      i++; // skip opening quote
+      const keyStart = i;
+      while (i < objectLiteral.length && objectLiteral[i] !== quote) {
+        if (objectLiteral[i] === "\\") i++;
+        i++;
+      }
+      const keyEnd = i;
+      i++; // skip closing quote
+      // At top level, check if this quoted string is an object key
+      if (depth === 0) {
+        let j = i;
+        while (j < objectLiteral.length && /\s/.test(objectLiteral[j]!)) j++;
+        if (objectLiteral[j] === ":") {
+          keys.push(objectLiteral.substring(keyStart, keyEnd));
+        }
+      }
+      continue;
+    }
+
+    // Unquoted identifier at top level: check if it's an object key
+    if (depth === 0 && /[a-zA-Z_]/.test(ch)) {
+      const keyStart = i;
+      while (i < objectLiteral.length && /[\w-]/.test(objectLiteral[i]!)) i++;
+      const keyEnd = i;
+      let j = i;
+      while (j < objectLiteral.length && /\s/.test(objectLiteral[j]!)) j++;
+      if (objectLiteral[j] === ":") {
+        keys.push(objectLiteral.substring(keyStart, keyEnd));
+      }
+      // Don't advance i — the char at i still needs processing
+      continue;
+    }
+
+    i++;
+  }
+
+  return keys;
+}
+
+// Identify regions belonging to parseLeafSpec* methods (package definition
+// parsing, not run definition parsing) so we can exclude their parseObject calls.
+function findLeafSpecRegions(source: string): Array<[number, number]> {
+  const regions: Array<[number, number]> = [];
+  const methodPattern = /parseLeafSpec\w*\s*=\s*async\s/g;
+  let m;
+  while ((m = methodPattern.exec(source)) !== null) {
+    // Find the opening brace of the method body
+    let braceIdx = source.indexOf("{", m.index);
+    if (braceIdx === -1) continue;
+    const end = findMatchingBrace(source, braceIdx);
+    if (end !== -1) {
+      regions.push([m.index, end]);
+    }
+  }
+  return regions;
+}
+
+const leafSpecRegions = findLeafSpecRegions(parserSource);
+
+function isInLeafSpec(offset: number): boolean {
+  return leafSpecRegions.some(([start, end]) => offset >= start && offset <= end);
+}
+
+// Find all `this.parseObject(` calls and extract the second argument's keys
+const parseObjectPattern = /this\.parseObject\s*\(/g;
+const parserKeySets: string[][] = [];
+let match;
+
+while ((match = parseObjectPattern.exec(parserSource)) !== null) {
+  // Skip parseObject calls inside parseLeafSpec* methods
+  if (isInLeafSpec(match.index)) continue;
+  const callStart = match.index + match[0].length;
+
+  // Find the second argument — skip the first arg by balancing parens/braces
+  // until we hit a comma at depth 0
+  let depth = 0;
+  let i = callStart;
+  let foundComma = false;
+
+  for (; i < parserSource.length; i++) {
+    const ch = parserSource[i];
+    if (ch === "(" || ch === "{" || ch === "[") depth++;
+    else if (ch === ")" || ch === "}" || ch === "]") depth--;
+    else if (ch === "," && depth === 0) {
+      foundComma = true;
+      i++; // skip the comma
+      break;
+    }
+    // Skip strings
+    else if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      i++;
+      while (i < parserSource.length && parserSource[i] !== quote) {
+        if (parserSource[i] === "\\") i++;
+        i++;
+      }
+    }
+  }
+
+  if (!foundComma) continue;
+
+  // Skip whitespace to find the opening brace of the second argument
+  while (i < parserSource.length && /\s/.test(parserSource[i]!)) i++;
+
+  // If second arg is not an object literal, skip (recursive calls pass `parsers` variable)
+  if (parserSource[i] !== "{") continue;
+
+  const braceStart = i;
+  const braceEnd = findMatchingBrace(parserSource, braceStart);
+  if (braceEnd === -1) continue;
+
+  const objectBody = parserSource.substring(braceStart + 1, braceEnd);
+  const keys = extractObjectKeys(objectBody);
+
+  if (keys.length > 0) {
+    parserKeySets.push(keys);
+  }
+}
+
+// --- Step 2: Build key-descriptions child sets for comparison ---
+
+// Normalize a key-descriptions path by stripping [] and * segments
+function normalizePath(p: string): string {
+  return p
+    .replace(/\[\]/g, "")
+    .split(".")
+    .filter((s) => s !== "*")
+    .join(".");
+}
+
+// Build: normalized parent → set of children from key-descriptions
+const descriptionGroups = new Map<string, Set<string>>();
+const wildcardParents = new Set<string>();
+
+for (const fullPath of Object.keys(keyDescriptions)) {
+  const lastDot = fullPath.lastIndexOf(".");
+  const rawParent = lastDot === -1 ? "" : fullPath.substring(0, lastDot);
+  let child = lastDot === -1 ? fullPath : fullPath.substring(lastDot + 1);
+
+  // Track wildcard parents (from parseGenericRecord, not parseObject)
+  if (child === "*") {
+    wildcardParents.add(normalizePath(rawParent));
+    continue;
+  }
+  if (child.endsWith("[]")) {
+    child = child.slice(0, -2);
+  }
+
+  const normalizedParent = normalizePath(rawParent);
+  if (!descriptionGroups.has(normalizedParent)) {
+    descriptionGroups.set(normalizedParent, new Set());
+  }
+  descriptionGroups.get(normalizedParent)!.add(child);
+}
+
+// --- Step 3: Match parser key sets against key-descriptions groups ---
+//
+// Strategy: each parseObject call produces a set of child keys. Each
+// key-descriptions parent path also has a set of child keys. We match them
+// by finding, for each parser key set, which description group(s) it's a
+// subset of (or equal to). Then we check both directions.
+
+// Flatten all parser keys into a set of individual keys, tagged by which
+// key set they came from, for reporting.
+// But the more useful check: for each parser key set, find its matching
+// description group, then verify all keys exist.
+
+let failures = 0;
+
+// Check 1: Every key in every parser key set should exist in SOME description group
+console.log("=== Keys accepted by parser but NOT in key-descriptions.ts ===\n");
+
+let foundParserOnly = false;
+
+for (const parserKeys of parserKeySets) {
+  // Find the best matching description group (most key overlap)
+  let bestMatch: { parent: string; children: Set<string> } | null = null;
+  let bestOverlap = 0;
+
+  for (const [parent, children] of descriptionGroups) {
+    const overlap = parserKeys.filter((k) => children.has(k)).length;
+    if (overlap > bestOverlap) {
+      bestOverlap = overlap;
+      bestMatch = { parent, children };
+    }
+  }
+
+  for (const key of parserKeys) {
+    // Check in best-matching group
+    if (bestMatch?.children.has(key)) continue;
+
+    // Check if the key leads to child entries in any group
+    const fullPath = bestMatch ? `${bestMatch.parent}.${key}` : key;
+    const hasChildren = [...descriptionGroups.keys()].some(
+      (p) => p === fullPath || p.startsWith(fullPath + "."),
+    );
+    if (hasChildren) continue;
+
+    // Check if documented under a wildcard parent
+    if (bestMatch && wildcardParents.has(bestMatch.parent)) continue;
+
+    // Check ALL groups as fallback (key might appear in multiple contexts)
+    let foundAnywhere = false;
+    for (const [parent, children] of descriptionGroups) {
+      if (children.has(key)) {
+        foundAnywhere = true;
+        break;
+      }
+      const fp = parent ? `${parent}.${key}` : key;
+      const hc = [...descriptionGroups.keys()].some(
+        (p) => p === fp || p.startsWith(fp + "."),
+      );
+      if (hc) {
+        foundAnywhere = true;
+        break;
+      }
+    }
+    if (foundAnywhere) continue;
+
+    console.log(
+      `  MISSING: "${key}" in parser key set [${parserKeys.join(", ")}]` +
+        (bestMatch ? ` (best match: ${bestMatch.parent || "(root)"})` : ""),
+    );
+    foundParserOnly = true;
+    failures++;
+  }
+}
+
+if (!foundParserOnly) {
+  console.log("  (none)\n");
+}
+
+// Check 2: Every key-descriptions entry should appear in SOME parser key set
+console.log(
+  "\n=== Keys in key-descriptions.ts but NOT accepted by parser ===\n",
+);
+
+let foundDescOnly = false;
+
+// Build a flat set of all parser-accepted keys for quick lookup
+const allParserKeys = new Set<string>();
+for (const keys of parserKeySets) {
+  for (const k of keys) {
+    allParserKeys.add(k);
+  }
+}
+
+for (const [normalizedParent, children] of descriptionGroups) {
+  for (const child of children) {
+    const fullPath = normalizedParent
+      ? `${normalizedParent}.${child}`
+      : child;
+
+    // Find the original key-descriptions path
+    const originalPath = Object.keys(keyDescriptions).find(
+      (k) => normalizePath(k) === fullPath,
+    );
+
+    // Skip acknowledged internal keys
+    if (
+      originalPath &&
+      !isKeyAutocomplete(originalPath) &&
+      !isKeyDocumented(originalPath)
+    ) {
+      continue;
+    }
+
+    // Skip children under wildcard parents (parseGenericRecord)
+    if (wildcardParents.has(normalizedParent)) continue;
+    const parentSegments = normalizedParent.split(".");
+    let isUnderWildcard = false;
+    for (let i = parentSegments.length; i >= 1; i--) {
+      if (wildcardParents.has(parentSegments.slice(0, i).join("."))) {
+        isUnderWildcard = true;
+        break;
+      }
+    }
+    if (isUnderWildcard) continue;
+
+    // Check if the key appears in any parser key set
+    if (allParserKeys.has(child)) continue;
+
+    console.log(
+      `  STALE: ${fullPath}${originalPath ? ` (from ${originalPath})` : ""}`,
+    );
+    foundDescOnly = true;
+    failures++;
+  }
+}
+
+if (!foundDescOnly) {
+  console.log("  (none)\n");
+}
+
+// Exit with appropriate code
+if (failures > 0) {
+  console.log(
+    `\n✗ ${failures} issue(s) found. Update key-descriptions.ts to fix.`,
+  );
+  process.exit(1);
+} else {
+  console.log(
+    "\n✓ All parser keys are accounted for in key-descriptions.ts.",
+  );
+  process.exit(0);
+}

--- a/src/key-descriptions.ts
+++ b/src/key-descriptions.ts
@@ -1,7 +1,39 @@
 // Flat mapping of dotted key paths to their descriptions, extracted from the RWX YAML JSON schema.
 // Used to provide hover information and documentation for keys in RWX YAML files.
 
-export const keyDescriptions: Record<string, string> = {
+export interface KeyDescriptionEntry {
+  description: string | null;
+  documented?: boolean; // default true
+  autocomplete?: boolean; // default true
+}
+
+export type KeyDescriptionValue = string | KeyDescriptionEntry;
+
+/** Returns the human-readable description for a key path, or null if missing/suppressed. */
+export function getKeyDescription(path: string): string | null {
+  const entry = keyDescriptions[path];
+  if (entry === undefined) return null;
+  if (typeof entry === "string") return entry;
+  return entry.description;
+}
+
+/** Whether the key should appear in autocomplete suggestions (default true). */
+export function isKeyAutocomplete(path: string): boolean {
+  const entry = keyDescriptions[path];
+  if (entry === undefined) return true;
+  if (typeof entry === "string") return true;
+  return entry.autocomplete !== false;
+}
+
+/** Whether the key should appear in hover docs (default true). */
+export function isKeyDocumented(path: string): boolean {
+  const entry = keyDescriptions[path];
+  if (entry === undefined) return true;
+  if (typeof entry === "string") return true;
+  return entry.documented !== false;
+}
+
+export const keyDescriptions: Record<string, KeyDescriptionValue> = {
   // Top-level properties
   "tasks":
     "An array of task definitions that form the core execution units of your workflow. Each task represents a discrete unit of work that executes in an isolated containerized environment. Tasks can execute shell commands, call reusable packages, or embed other run definitions. Tasks support sophisticated dependency management through 'use' (inherits outputs and filesystem) and 'after' (ordering only), enabling complex workflows with parallel execution, content-based caching, and flexible artifact management.",
@@ -13,6 +45,8 @@ export const keyDescriptions: Record<string, string> = {
     "Global tool cache configuration that enables incremental caching for tasks across runs. Tool caches preserve filesystem contents from previous task executions, allowing tasks like dependency installations to perform incremental updates instead of starting from scratch. When a task has a cache miss, the tool cache provides the filesystem state from the most recent execution. Tool caches are evicted after 48 hours and must be configured with a vault for security. Tool caches are useful for package managers (npm, yarn, bundle), Docker builds, compilation tasks, and other tasks that benefit from incremental updates.",
   "base":
     "Base container layer configuration that defines the operating system, version, and RWX configuration tag for task execution. All tasks in the run use this base layer. The currently supported base layers are Ubuntu 22.04 (tag 1.1) and Ubuntu 24.04 (tag 1.2). The base layer determines available system packages, pre-installed Docker version, and tool cache compatibility. Different embedded runs can specify different base layers than their parent run.",
+  "aliases":
+    "YAML aliases defined at the top level for reuse across the run definition. Aliases allow you to define common configurations once and reference them throughout the file using YAML anchors (&name) and aliases (*name).",
 
   // Task properties (merged from CommandTask, PackageTask, EmbeddedRunTask)
   "tasks[].key":
@@ -57,10 +91,11 @@ export const keyDescriptions: Record<string, string> = {
     "Maximum time for the agent to report its healthiness (e.g., '15m' or '1h'). If an agent has not reported that it is healthy within this time frame, the task will fail. The default value is 1 minute per 1 hour of configured timeout. This helps detect and handle unresponsive or stuck agents during task execution.",
   "tasks[].auto-cancel":
     "Whether to automatically cancel this task when superseded by a newer run. Supports template expressions.",
-  "tasks[].deduplicate-output-filesystem":
-    "Whether to deduplicate the output filesystem for this task. Supports template expressions.",
-  "tasks[].bootstrapping":
-    "Whether this task is a bootstrapping task. Bootstrapping tasks run in a minimal environment before the full base layer is available.",
+  "tasks[].bootstrapping": {
+    description: "",
+    documented: false,
+    autocomplete: false,
+  },
   "tasks[].call":
     "The package identifier or embedded run source. For packages: use name/version format (e.g., 'namespace/package-name 1.2.0') for semantic versioning or SHA-256 digest for exact version pinning. For embedded runs: a file path relative to the current run definition, an absolute path, or a template expression (commonly using ${{ run.mint-dir }}).",
   "tasks[].with":
@@ -87,8 +122,11 @@ export const keyDescriptions: Record<string, string> = {
     "Whether to use tmpfs (in-memory filesystem) for improved I/O performance. Tmpfs is useful for tasks with heavy disk I/O that can benefit from memory-backed storage (e.g. task that install node modules), but requires sufficient memory allocation. Any tasks with significant filesystem I/O that fits in ~70% of available memory will benefit from tmpfs.",
   "tasks[].agent.spot":
     "Whether to use spot instances for task execution. When true, ephemeral instances are used that may be preempted at any time but offer cost savings. When false or omitted, standard on-demand instances are used with guaranteed availability and stable performance. Choose spot instances for fault-tolerant workloads that can handle interruptions. Tasks with spot agents that are interrupted are automatically retried by RWX.",
-  "tasks[].agent.placement":
-    "Agent placement strategy. 'spot' uses ephemeral instances that may be preempted but offer cost savings; 'standard' uses on-demand instances with guaranteed availability. Preferred over the 'spot' boolean property.",
+  "tasks[].agent.placement": {
+    description: "",
+    documented: false,
+    autocomplete: false,
+  },
   "tasks[].agent.ipv6":
     "Whether to enable IPv6 networking for the task agent. Supports template expressions.",
 
@@ -109,6 +147,11 @@ export const keyDescriptions: Record<string, string> = {
   // Environment variable object properties
   "tasks[].env.*.value":
     "The environment variable value. Supports template expressions for dynamic values from other tasks, initialization parameters, or event context.",
+  "tasks[].env.*.cache": {
+    description: "",
+    documented: false,
+    autocomplete: false,
+  },
   "tasks[].env.*.cache-key":
     "Whether this environment variable should be included in cache key generation. 'included' (default): variable value affects cache key. 'excluded': variable ignored for caching, enabling cache hits with ephemeral values like credentials.",
 
@@ -117,6 +160,8 @@ export const keyDescriptions: Record<string, string> = {
     "Inherit environment variables from dependency tasks. 'all-used-tasks' inherits from all tasks listed in 'use', or specify an array of specific task keys. Note: inheritance is automatic for 'use' dependencies; this setting provides explicit control.",
   "tasks[].env-config.merge":
     "Merge strategies for environment variables with the same name from multiple sources.",
+  "tasks[].env-config.merge.*.strategy":
+    "Merge strategy for this environment variable. Use 'join' to concatenate values from multiple sources with a separator.",
   "tasks[].env-config.merge.*.by":
     "Separator string for join strategy. Common values: ':' for PATH-like variables, ',' for comma-separated lists, ' ' for space-separated values.",
 
@@ -175,6 +220,14 @@ export const keyDescriptions: Record<string, string> = {
     "File or directory path to collect.",
   "tasks[].outputs.filesystem":
     "Filesystem output configuration. Set to false to disable outputting a filesystem layer from this task, or configure filtering for preserving specific files after task completion.",
+  "tasks[].outputs.filesystem.deduplicate":
+    "Whether to deduplicate the output filesystem for this task. Deduplication reduces storage by eliminating duplicate file content.",
+  "tasks[].outputs.filesystem.filter":
+    "Filter configuration for filesystem outputs, specifying which files to preserve after task completion.",
+  "tasks[].outputs.filesystem.filter.workspace":
+    "Filter files from the workspace directory in filesystem output.",
+  "tasks[].outputs.filesystem.filter.system":
+    "Filter files from the system directory in filesystem output.",
 
   // Retry configuration (tasks[].retry.*)
   "tasks[].retry.count":
@@ -184,15 +237,18 @@ export const keyDescriptions: Record<string, string> = {
   "tasks[].retry.action":
     "Action to take on retry.",
 
-  // Filter object properties
+  // Filter object properties (uses parseGenericRecord — workspace is fixed, other keys are task names)
+  "tasks[].filter.*": {
+    description: "",
+    documented: false,
+    autocomplete: false,
+  },
   "tasks[].filter.workspace":
     "Filter files from the workspace directory.",
-  "tasks[].filter.artifacts":
-    "Filter files from artifact dependencies. Keys are task keys, values are filter sets specifying which artifact files to include.",
 
   // Trigger properties (on.*)
   "on.github":
-    "GitHub event triggers for automated run execution. Supports push events (on branch updates), pull_request events (on PR lifecycle), and merge_group events. Each trigger provides rich event context accessible via template expressions.",
+    "GitHub event triggers for automated run execution. Supports push events (on branch updates) and pull_request events (on PR lifecycle). Each trigger provides rich event context accessible via template expressions.",
   "on.gitlab":
     "GitLab event triggers for automated run execution. Supports push events (branch updates), tag-push events (tag creation), and merge-request events (MR lifecycle). Each trigger provides GitLab-specific event context and supports conditional execution, initialization parameters, target tasks, and custom run titles.",
   "on.cron":
@@ -211,9 +267,6 @@ export const keyDescriptions: Record<string, string> = {
     "Triggers for GitHub push events (branch updates, tag pushes). Can be a single trigger object or an array of trigger objects for different configurations. Provides event context: event.git.branch, event.git.sha, event.git.ref, event.git.tag, event.github.push.head_commit.message, event.github.push.repository.clone_url, event.github.push.sender.login.",
   "on.github.pull_request":
     "Triggers for GitHub pull request events (opened, reopened, synchronize, closed). Can be a single trigger object or an array of trigger objects. Default actions: [opened, reopened, synchronize]. Provides event context: event.git.branch, event.git.sha, event.git.ref, event.github.pull_request.number, event.github.pull_request.pull_request.title.",
-  "on.github.merge_group":
-    "Triggers for GitHub merge group events. Can be a single trigger object or an array of trigger objects.",
-
   // GitHub push trigger properties
   "on.github.push.init":
     "Initialization parameters passed to the run or embedded run.",
@@ -248,24 +301,6 @@ export const keyDescriptions: Record<string, string> = {
   "on.github.pull_request.status-checks":
     "GitHub/GitLab status check configuration. Can be a boolean to enable/disable all checks, a string expression, an array of custom checks, or an object with default and custom check configurations. Status checks report task execution status back to the version control system.",
 
-  // GitHub merge_group trigger properties
-  "on.github.merge_group.init":
-    "Initialization parameters passed to the run or embedded run.",
-  "on.github.merge_group.if":
-    "Condition for trigger activation.",
-  "on.github.merge_group.target":
-    "Specific tasks to execute when triggered.",
-  "on.github.merge_group.title":
-    "Custom title for the run.",
-  "on.github.merge_group.start":
-    "Whether the run starts automatically when triggered or must be started manually.",
-  "on.github.merge_group.region":
-    "The region in which to execute the run when this trigger fires.",
-  "on.github.merge_group.actions":
-    "Merge group actions that trigger the run.",
-  "on.github.merge_group.status-checks":
-    "GitHub/GitLab status check configuration. Can be a boolean to enable/disable all checks, a string expression, an array of custom checks, or an object with default and custom check configurations. Status checks report task execution status back to the version control system.",
-
   // GitLab trigger properties
   "on.gitlab.push":
     "Triggers for GitLab push events (branch updates).",
@@ -274,21 +309,31 @@ export const keyDescriptions: Record<string, string> = {
   "on.gitlab.merge-request":
     "Triggers for GitLab merge request events (MR lifecycle).",
 
-  // GitLab push/tag-push trigger properties
+  // GitLab push trigger properties
   "on.gitlab.push.init":
     "Initialization parameters passed to the run or embedded run.",
+  "on.gitlab.push.if":
+    "Condition for trigger activation.",
   "on.gitlab.push.target":
     "Specific tasks to execute when triggered.",
+  "on.gitlab.push.title":
+    "Custom title for the run.",
   "on.gitlab.push.start":
     "Whether the run starts automatically when triggered or must be started manually.",
   "on.gitlab.push.region":
     "The region in which to execute the run when this trigger fires.",
   "on.gitlab.push.status-checks":
     "GitHub/GitLab status check configuration. Status checks report task execution status back to the version control system.",
+
+  // GitLab tag-push trigger properties
   "on.gitlab.tag-push.init":
     "Initialization parameters passed to the run or embedded run.",
+  "on.gitlab.tag-push.if":
+    "Condition for trigger activation.",
   "on.gitlab.tag-push.target":
     "Specific tasks to execute when triggered.",
+  "on.gitlab.tag-push.title":
+    "Custom title for the run.",
   "on.gitlab.tag-push.start":
     "Whether the run starts automatically when triggered or must be started manually.",
   "on.gitlab.tag-push.region":
@@ -299,12 +344,18 @@ export const keyDescriptions: Record<string, string> = {
   // GitLab merge-request trigger properties
   "on.gitlab.merge-request.init":
     "Initialization parameters passed to the run or embedded run.",
+  "on.gitlab.merge-request.if":
+    "Condition for trigger activation.",
   "on.gitlab.merge-request.target":
     "Specific tasks to execute when triggered.",
+  "on.gitlab.merge-request.title":
+    "Custom title for the run.",
   "on.gitlab.merge-request.start":
     "Whether the run starts automatically when triggered or must be started manually.",
   "on.gitlab.merge-request.region":
     "The region in which to execute the run when this trigger fires.",
+  "on.gitlab.merge-request.actions":
+    "Merge request actions that trigger the run.",
   "on.gitlab.merge-request.status-checks":
     "GitHub/GitLab status check configuration. Status checks report task execution status back to the version control system.",
 
@@ -403,10 +454,6 @@ export const keyDescriptions: Record<string, string> = {
     "The region in which to execute the run when this trigger fires.",
 
   // Status checks properties
-  "status-checks.enabled":
-    "Whether status checks are enabled. Can be a boolean or a template expression.",
-  "status-checks.name":
-    "Default name for status checks. Supports template expressions.",
   "status-checks.default":
     "Configuration for the default status check that reports overall run status.",
   "status-checks.default.enabled":

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,11 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import * as path from "path";
 import * as fs from "fs";
 import { YamlParser } from "../support/parser";
-import { keyDescriptions } from "./key-descriptions";
+import {
+  keyDescriptions,
+  getKeyDescription,
+  isKeyAutocomplete,
+} from "./key-descriptions";
 
 // RWX Package types
 interface RWXPackage {
@@ -1308,11 +1312,12 @@ connection.onCompletion(
             const fullPath = parentPath ? `${parentPath}.${key}` : key;
             // Look up description — try with [] suffix for array keys too
             const description =
-              keyDescriptions[fullPath] ||
-              keyDescriptions[fullPath + "[]"] ||
-              keyDescriptions[`${fullPath}[].key`]
-                ? keyDescriptions[fullPath] || keyDescriptions[fullPath + "[]"]
-                : undefined;
+              getKeyDescription(fullPath) ??
+              getKeyDescription(fullPath + "[]") ??
+              (getKeyDescription(`${fullPath}[].key`)
+                ? getKeyDescription(fullPath) ?? getKeyDescription(fullPath + "[]")
+                : null) ??
+              undefined;
             return {
               label: key,
               kind: CompletionItemKind.Property,
@@ -1583,8 +1588,8 @@ function buildKeyCompletionMap(): Map<string, string[]> {
     // Skip wildcard entries like "*.value" or "*.cache-key"
     if (childKey === "*") continue;
 
-    // Skip internal keys that shouldn't be suggested to users
-    if (childKey === "bootstrapping") continue;
+    // Skip keys marked as not autocomplete-eligible
+    if (!isKeyAutocomplete(fullPath)) continue;
 
     if (!map.has(parent)) {
       map.set(parent, []);
@@ -2095,7 +2100,7 @@ connection.onHover(
     const keyPath = getYamlKeyPathAtPosition(document, params.position);
     let keyHoverPrefix: string | null = null;
     if (keyPath) {
-      const description = keyDescriptions[keyPath];
+      const description = getKeyDescription(keyPath);
       if (description) {
         keyHoverPrefix = `**\`${keyPath.split(".").pop()}\`**\n\n${description}`;
       }


### PR DESCRIPTION
## Summary

- Makes `key-descriptions.ts` the single source of truth for which keys get completions and hover docs, replacing ad-hoc hardcoded skips (e.g. `if (childKey === "bootstrapping") continue`)
- Adds `KeyDescriptionEntry` type with `documented` and `autocomplete` flags, plus `getKeyDescription()`, `isKeyAutocomplete()`, and `isKeyDocumented()` helpers
- Updates `server.ts` consumers (completion, hover, `buildKeyCompletionMap`) to use helpers instead of raw map access
- Removes stale entries: `merge_group` + children, `deduplicate-output-filesystem`, `status-checks.enabled/name`, `filter.artifacts`
- Adds missing parser-accepted keys: `aliases`, `outputs.filesystem.deduplicate/filter/*`, `env-config.merge.*.strategy`, `env.*.cache` (deprecated), gitlab `push/tag-push.if/title`, `merge-request.if/title/actions`
- Adds `check-key-descriptions` CI task that **statically extracts** accepted keys from `parser.js` by finding all `parseObject()` call sites and parsing their object literal arguments — no hardcoded key lists, so the check automatically detects new/removed parser keys without updating the script

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 118 tests pass
- [x] `npm run check-key-descriptions` — exits 0
- [x] CI passes