### PR TITLE
Fire client update dispatches on language-server main pushes

### DIFF
--- a/.rwx/dispatch-client-updates.yml
+++ b/.rwx/dispatch-client-updates.yml
@@ -1,0 +1,34 @@
+on:
+  github:
+    push:
+      if: ${{ event.git.branch == "main" }}
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+base:
+  image: ubuntu:24.04
+  config: rwx/base 1.1.0
+
+tasks:
+  - key: rwx-cli
+    call: rwx/install-cli 4.0.4
+
+  - key: dispatch-cli-update
+    use: rwx-cli
+    cache: false
+    run: |
+      rwx dispatch cli-language-server-update \
+        --title "Update language-server-ref to rwx-cloud/language-server@${COMMIT_SHA:0:7}"
+    env:
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      COMMIT_SHA: ${{ init.commit-sha }}
+
+  - key: dispatch-vscode-extension-update
+    use: rwx-cli
+    cache: false
+    run: |
+      rwx dispatch vscode-extension-language-server-update \
+        --title "Update language server to rwx-cloud/language-server@${COMMIT_SHA:0:7}"
+    env:
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      COMMIT_SHA: ${{ init.commit-sha }}


### PR DESCRIPTION
### Background

- [RWX-835](https://linear.app/rwx-cloud/issue/RWX-835/fire-dispatches-to-cli-and-vscode-extension-when-language-server-pr-is)
- rwx-cloud/rwx#510 (turned the cli's language-server-update cron into a dispatch)
- rwx-cloud/vscode-extension#61 (added the vscode-extension language-server-update dispatch)

### Problem

The cli and vscode-extension repos each now expose a dispatch (`cli-language-server-update` and `vscode-extension-language-server-update`) that pulls the latest language-server `main`, bumps their pinned ref / submodule, and opens a PR. Nothing actually fires those dispatches today, so downstream consumers still drift until someone kicks them off manually.

### Solution

Add `.rwx/dispatch-client-updates.yml`. On every push to `main`, it dispatches both client update runs in parallel via the RWX CLI, tagged with the short SHA of the merged commit in the run title.

- Both dispatches are independent tasks so one failing doesn't block the other.
- Each dispatch is idempotent on the downstream side — if the ref/submodule is already up to date, no PR is created.
- Relies on `secrets.RWX_ACCESS_TOKEN` (same pattern as `vscode-extension/.rwx/auto-publish.yml`).