### PR TITLE
Only dispatch client updates when src or support files change

### DIFF
--- a/.rwx/dispatch-client-updates.yml
+++ b/.rwx/dispatch-client-updates.yml
@@ -4,6 +4,8 @@ on:
       if: ${{ event.git.branch == "main" }}
       init:
         commit-sha: ${{ event.git.sha }}
+        base-ref: ${{ event.github.push.before }}
+        head-ref: ${{ event.git.sha }}
 
 base:
   image: ubuntu:24.04
@@ -13,7 +15,23 @@ tasks:
   - key: rwx-cli
     call: rwx/install-cli 4.0.4
 
+  - key: github-cli
+    call: github/install-cli 1.0.10
+
+  - key: src-changes
+    use: github-cli
+    call: github/compare 1.0.8
+    with:
+      repository: rwx-cloud/language-server
+      base-ref: ${{ init.base-ref }}
+      head-ref: ${{ init.head-ref }}
+      github-token: ${{ github['rwx-cloud'].token }}
+      patterns: |
+        src/**
+        support/**
+
   - key: dispatch-cli-update
+    if: ${{ tasks.src-changes.values.have-changes }}
     use: rwx-cli
     cache: false
     run: |
@@ -24,6 +42,7 @@ tasks:
       COMMIT_SHA: ${{ init.commit-sha }}
 
   - key: dispatch-vscode-extension-update
+    if: ${{ tasks.src-changes.values.have-changes }}
     use: rwx-cli
     cache: false
     run: |


### PR DESCRIPTION
### Problem

`.rwx/dispatch-client-updates.yml` currently fires the `cli-language-server-update` and `vscode-extension-language-server-update` dispatches on every push to `main`, even when the merge only touched docs, CI configs, or other non-runtime files. That produces noisy client-side runs that don't actually pick up anything new.

### Solution

- Add `base-ref` / `head-ref` to the trigger init so we can compare the pushed range.
- Install `github/install-cli` and run `github/compare` against `src/**` and `support/**` (parser.js lives under `support/`, so parser bumps should still flow through).
- Gate both dispatch tasks on `tasks.src-changes.values.have-changes`.

`rwx lint` passes locally.

#### Further confirmation needed

- [ ] Verify on the next push to `main` that the dispatches only fire when something under `src/**` or `support/**` actually changed.