### PR TITLE
Fix client update conditional logic to not use github token, since it's not available

### DIFF
--- a/.rwx/dispatch-client-updates.yml
+++ b/.rwx/dispatch-client-updates.yml
@@ -25,7 +25,6 @@ tasks:
       repository: rwx-cloud/language-server
       base-ref: ${{ init.base-ref }}
       head-ref: ${{ init.head-ref }}
-      github-token: ${{ github['rwx-cloud'].token }}
       patterns: |
         src/**
         support/**


### PR DESCRIPTION
Fast-follow for https://github.com/rwx-cloud/language-server/pull/67

This repo is open-source and is configured in Cloud to not expose github credentials, so calling `github.token` or `github['rwx-cloud'].token` is not supported.

That causes the run to fail like this: https://cloud.rwx.com/mint/rwx/tasks/0ac4436a70369513779a3e467e7dfea9/tasks

Confirmed with a local run that the github/compare packages works just fine without it.
