### PR TITLE
Use cloud bot token for github/compare package

### DIFF
--- a/.rwx/dispatch-client-updates.yml
+++ b/.rwx/dispatch-client-updates.yml
@@ -6,6 +6,10 @@ on:
         commit-sha: ${{ event.git.sha }}
         base-ref: ${{ event.github.push.before }}
         head-ref: ${{ event.git.sha }}
+  cli:
+    init:
+      commit-sha: ${{ event.git.sha }}
+      head-ref: ${{ event.git.sha }}
 
 base:
   image: ubuntu:24.04
@@ -25,6 +29,7 @@ tasks:
       repository: rwx-cloud/language-server
       base-ref: ${{ init.base-ref }}
       head-ref: ${{ init.head-ref }}
+      github-token: ${{ github-apps.rwx-cloud-bot.token }}
       patterns: |
         src/**
         support/**


### PR DESCRIPTION
Got burned in my local testing of #68 because the github token is cache-key-excluded.

Sample run using this token: https://cloud.rwx.com/mint/rwx/runs/974d7eeb922649828f3a8fc4a1005f31
