### PR TITLE
Parse local packages with the local package grammar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ This directory contains the Language Server Protocol (LSP) implementation for RW
 
 - **File Detection**: Only processes files in `.mint/` or `.rwx/` directories with `.yml` or `.yaml` extensions
 - **Parser Integration**: Uses RWX-specific YAML parser for detailed error reporting and validation
+- **Local Packages**: Files that set `package: true` at the top level are parsed with the local package grammar instead of the run definition grammar
 - **Real-time Diagnostics**: Provides syntax errors, semantic validation, and package version warnings
 
 #### Intelligent Completion

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,14 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import * as path from "path";
 import * as fs from "fs";
-import { YamlParser, Leaves } from "../support/parser";
+import {
+  YamlParser,
+  Leaves,
+  type PartialLocalPackage,
+  type PartialRunDefinition,
+  type PartialTaskDefinition,
+  type UserMessage,
+} from "../support/parser";
 import {
   keyDescriptions,
   getKeyDescription,
@@ -395,6 +402,39 @@ function stackTraceToRelatedInformation(
   }));
 }
 
+function isParsingError(
+  error: unknown,
+): error is Error & { asMessages(): UserMessage[] } {
+  return (
+    error instanceof Error &&
+    typeof (error as { asMessages?: unknown }).asMessages === "function"
+  );
+}
+
+// Mirrors YamlParser.safelyParseRun, but parses with the local package grammar.
+async function safelyParseLocalPackage(
+  fileName: string,
+  source: string,
+): Promise<{
+  partialLocalPackage: PartialLocalPackage;
+  errors: UserMessage[];
+}> {
+  try {
+    const parser = YamlParser.createParser(fileName, source, false);
+    const partialLocalPackage = await parser.parseLocalPackage();
+    const { errors } = parser.formatMessages();
+    return { partialLocalPackage, errors };
+  } catch (error) {
+    if (isParsingError(error)) {
+      return {
+        partialLocalPackage: { tasks: [], warningMessages: [] },
+        errors: error.asMessages(),
+      };
+    }
+    throw error;
+  }
+}
+
 async function validateTextDocumentForDiagnostics(
   textDocument: TextDocument,
 ): Promise<Diagnostic[]> {
@@ -418,12 +458,26 @@ async function validateTextDocumentForDiagnostics(
   const diagnostics: Diagnostic[] = [];
 
   try {
-    // Parse the document using the Mint parser
+    // Parse the document using the Mint parser. Files that set `package: true`
+    // are local packages and use a different grammar than run definitions.
     const fileName = textDocument.uri.replace("file://", "");
-    const result = await YamlParser.safelyParseRun(fileName, text);
+    let errors: UserMessage[];
+    let warningMessages: PartialRunDefinition["warningMessages"] | undefined;
+    let tasks: PartialTaskDefinition[] | undefined;
+    if (YamlParser.isLocalPackageDefinition(text)) {
+      const result = await safelyParseLocalPackage(fileName, text);
+      errors = result.errors;
+      warningMessages = result.partialLocalPackage.warningMessages;
+      tasks = result.partialLocalPackage.tasks;
+    } else {
+      const result = await YamlParser.safelyParseRun(fileName, text);
+      errors = result.errors;
+      warningMessages = result.partialRunDefinition?.warningMessages;
+      tasks = result.partialRunDefinition?.tasks;
+    }
 
     // Convert parser errors to diagnostics
-    for (const error of result.errors) {
+    for (const error of errors) {
       // Get the most specific stack trace entry (usually the last one)
       const stackEntry = error.stackTrace?.[0];
       const line = stackEntry?.line ?? error.line ?? 1;
@@ -463,8 +517,8 @@ async function validateTextDocumentForDiagnostics(
       diagnostics.push(diagnostic);
     }
 
-    if (result.partialRunDefinition?.warningMessages) {
-      for (const warning of result.partialRunDefinition.warningMessages) {
+    if (warningMessages) {
+      for (const warning of warningMessages) {
         const stackEntry = warning.stackTrace?.[0];
         const line = stackEntry?.line ?? warning.line ?? 1;
         const column = stackEntry?.column ?? warning.column ?? 1;
@@ -505,8 +559,8 @@ async function validateTextDocumentForDiagnostics(
       }
     }
 
-    if (result.partialRunDefinition?.tasks) {
-      for (const task of result.partialRunDefinition.tasks) {
+    if (tasks) {
+      for (const task of tasks) {
         if (task.warningMessages) {
           for (const warning of task.warningMessages) {
             const stackEntry = warning.stackTrace?.[0];
@@ -577,15 +631,15 @@ async function validateTextDocumentForDiagnostics(
   }
 }
 
-// Helper function to extract task keys from parsed result
-function extractTaskKeys(result: any): string[] {
-  if (!result?.partialRunDefinition?.tasks) {
+// Helper function to extract task keys from parsed tasks
+function extractTaskKeys(tasks: PartialTaskDefinition[] | undefined): string[] {
+  if (!tasks) {
     return [];
   }
 
-  return result.partialRunDefinition.tasks
-    .map((task: any) => task.key)
-    .filter((key: string) => key && typeof key === "string" && key !== "#fake");
+  return tasks
+    .map((task) => task.key)
+    .filter((key) => key && typeof key === "string" && key !== "#fake");
 }
 
 // Helper function to find task definition location in document
@@ -1213,9 +1267,13 @@ connection.onCompletion(
           }
         }
 
-        const result = await YamlParser.safelyParseRun(fileName, text);
+        const tasks = YamlParser.isLocalPackageDefinition(text)
+          ? (await safelyParseLocalPackage(fileName, text)).partialLocalPackage
+              .tasks
+          : (await YamlParser.safelyParseRun(fileName, text))
+              .partialRunDefinition?.tasks;
 
-        const taskKeys = extractTaskKeys(result);
+        const taskKeys = extractTaskKeys(tasks);
 
         // Return completion items for task keys
         return taskKeys.map((key, index) => ({
@@ -2573,6 +2631,19 @@ connection.onRequest("rwx/dumpDebugData", async (params: { uri: string }) => {
 
     const text = document.getText();
     const fileName = document.uri.replace("file://", "");
+
+    if (YamlParser.isLocalPackageDefinition(text)) {
+      const result = await safelyParseLocalPackage(fileName, text);
+      return {
+        fileName,
+        isMintFile: true,
+        parseResult: {
+          partialLocalPackage: result.partialLocalPackage,
+          errors: result.errors,
+        },
+      };
+    }
+
     const result = await YamlParser.safelyParseRun(fileName, text);
 
     return {

--- a/support/parser.d.ts
+++ b/support/parser.d.ts
@@ -240,6 +240,8 @@ export interface YamlParser {
     partialRunDefinition: PartialRunDefinition;
     errors: UserMessage[];
   }>;
+  parseLocalPackage(): Promise<PartialLocalPackage>;
+  formatMessages(): { errors: UserMessage[] };
 }
 
 export namespace YamlParser {
@@ -250,6 +252,12 @@ export namespace YamlParser {
     partialRunDefinition: PartialRunDefinition;
     errors: UserMessage[];
   }>;
+  export function isLocalPackageDefinition(source: string): boolean;
+  export function createParser(
+    fileName: string,
+    source: string,
+    errorOnMissingBase?: boolean,
+  ): YamlParser;
 }
 
 export type BaseTrigger = {
@@ -599,6 +607,15 @@ export type PartialRunDefinition = {
       frame?: string;
     };
   }>;
+};
+
+export type PartialLocalPackage = {
+  parameters?: unknown;
+  concurrencyPools?: PartialConcurrencyPool[];
+  toolCache?: PartialRunToolCache;
+  defaults?: unknown;
+  tasks: PartialTaskDefinition[];
+  warningMessages: PartialRunDefinition["warningMessages"];
 };
 
 export const DEFAULT_AGENT_SPECIFICATION: {

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -98,6 +98,46 @@ tasks:
       `);
     });
 
+    it("provides task completions in use context inside a local package", async () => {
+      const yamlContent = `
+package: true
+
+tasks:
+  - key: build
+    run: npm run build
+  - key: test
+    run: npm test
+  - key: deploy
+    use: `;
+
+      const filePath = await createTestFile(
+        testEnv.mintDir,
+        "packages/tasks.yml",
+        yamlContent
+      );
+
+      const textDocument = {
+        uri: `file://${filePath}`,
+        languageId: "yaml",
+        version: 1,
+        text: yamlContent,
+      };
+
+      server.sendNotification("textDocument/didOpen", { textDocument });
+
+      const completions = await server.sendRequest<CompletionItem[]>(
+        "textDocument/completion",
+        {
+          textDocument: { uri: textDocument.uri },
+          position: Position.create(9, 9),
+        }
+      );
+
+      const labels = completions.map((completion) => completion.label);
+      expect(labels).toContain("build");
+      expect(labels).toContain("test");
+    });
+
     it("provides task completions in array use context", async () => {
       const yamlContent = `tasks:
   - key: build

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -664,4 +664,122 @@ tasks:
       expect(errors).toEqual([]);
     });
   });
+
+  describe("Local Package Files", () => {
+    it("parses files with `package: true` as local packages, not run definitions", async () => {
+      const localPackageContent = `
+package: true
+
+tasks:
+  - key: hello
+    run: echo "Hello, World!"
+`;
+
+      const filePath = await createTestFile(
+        testEnv.mintDir,
+        "packages/setup.yml",
+        localPackageContent,
+      );
+
+      const textDocument = {
+        uri: `file://${filePath}`,
+        languageId: "yaml",
+        version: 1,
+        text: localPackageContent,
+      };
+
+      server.sendNotification("textDocument/didOpen", { textDocument });
+
+      const result = await server.sendRequest<DocumentDiagnosticReport>(
+        "textDocument/diagnostic",
+        {
+          textDocument: { uri: textDocument.uri },
+        },
+      );
+
+      expect(result.kind).toBe("full");
+      assert("items" in result);
+      expect(result.items).toEqual([]);
+    });
+
+    it("reports local package grammar errors", async () => {
+      const localPackageContent = `
+package: true
+
+base:
+  os: ubuntu 24.04
+
+tasks:
+  - key: hello
+    run: echo "Hello, World!"
+`;
+
+      const filePath = await createTestFile(
+        testEnv.mintDir,
+        "packages/setup.yml",
+        localPackageContent,
+      );
+
+      const textDocument = {
+        uri: `file://${filePath}`,
+        languageId: "yaml",
+        version: 1,
+        text: localPackageContent,
+      };
+
+      server.sendNotification("textDocument/didOpen", { textDocument });
+
+      const result = await server.sendRequest<DocumentDiagnosticReport>(
+        "textDocument/diagnostic",
+        {
+          textDocument: { uri: textDocument.uri },
+        },
+      );
+
+      expect(result.kind).toBe("full");
+      assert("items" in result);
+      const diagnostic = result.items[0];
+      assert(diagnostic);
+      expect(diagnostic.severity).toBe(DiagnosticSeverity.Error);
+      expect(diagnostic.source).toBe("rwx-run-parser");
+      expect(diagnostic.message).toContain(
+        "A local package cannot configure `base`",
+      );
+    });
+
+    it("reports an error when a local package has no tasks", async () => {
+      const localPackageContent = `package: true\n`;
+
+      const filePath = await createTestFile(
+        testEnv.mintDir,
+        "packages/setup.yml",
+        localPackageContent,
+      );
+
+      const textDocument = {
+        uri: `file://${filePath}`,
+        languageId: "yaml",
+        version: 1,
+        text: localPackageContent,
+      };
+
+      server.sendNotification("textDocument/didOpen", { textDocument });
+
+      const result = await server.sendRequest<DocumentDiagnosticReport>(
+        "textDocument/diagnostic",
+        {
+          textDocument: { uri: textDocument.uri },
+        },
+      );
+
+      expect(result.kind).toBe("full");
+      assert("items" in result);
+      const diagnostic = result.items[0];
+      assert(diagnostic);
+      expect(diagnostic.severity).toBe(DiagnosticSeverity.Error);
+      expect(diagnostic.message).toContain(
+        "A local package must contain a `tasks` key",
+      );
+    });
+  });
 });


### PR DESCRIPTION
Files that set `package: true` at the top level are local packages, not run definitions. Parsing them with the run definition grammar flagged the whole file with "this file is a local package, so it cannot be used as a run definition". Classify documents with YamlParser.isLocalPackageDefinition and parse local packages with parseLocalPackage instead, for diagnostics, task-key completion, and the debug data dump.
