### PR TITLE
Report the parser review and fix published package parsing

### DIFF
--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -99,7 +99,7 @@ tasks:
 
   - key: review-parser-update
     if: ${{ tasks.check-parser-changes.values.have-changes && tasks.parser-update-exists.values.parser-update-exists == "false" }}
-    use: [code, claude-cli]
+    use: [code, claude-cli, github-cli]
     run: |
       BRANCH=$RWX_GIT_REF_NAME
       git fetch origin "$BRANCH"
@@ -113,22 +113,55 @@ tasks:
         --output-format json \
         > $RWX_ARTIFACTS/claude-output.json
 
-      git add support/parser.d.ts src/key-descriptions.ts src/server.ts
-      
-      if [ -z "$(git diff --name-only --cached)" ]; then
-        git commit --allow-empty -m "Review parser update (no changes)"
-        exit 0
-      else
-        git commit -m "Review parser update"
+      # `--output-format json` with `--verbose` emits an array of messages.
+      # The final `result` message carries the summary and the session id.
+      RESULT_MSG='if type == "array" then (map(select(.type == "result")) | last) else . end'
+      SUMMARY="$RWX_ARTIFACTS/review-summary.md"
+      SESSION_ID="$(jq -r "$RESULT_MSG | .session_id // \"unknown\"" "$RWX_ARTIFACTS/claude-output.json" 2>/dev/null || echo "unknown")"
+      jq -r "$RESULT_MSG | .result // empty" "$RWX_ARTIFACTS/claude-output.json" > "$SUMMARY" 2>/dev/null || true
+      if [ ! -s "$SUMMARY" ]; then
+        echo "Claude returned no summary. Read the claude-output.json artifact." > "$SUMMARY"
       fi
 
-      git push -u origin "$BRANCH"
+      echo "===== Claude review summary (session $SESSION_ID) ====="
+      cat "$SUMMARY"
+      echo "===== end of Claude review summary ====="
+
+      git add support/parser.d.ts src/key-descriptions.ts src/server.ts scripts/compare-parser-keys.ts
+
+      SKIPPED="$(git diff --name-only -- . ':!support/parser.js')"
+      if [ -n "$SKIPPED" ]; then
+        echo "WARNING: Claude changed files that this task does not commit:"
+        echo "$SKIPPED"
+      fi
+
+      if [ -z "$(git diff --name-only --cached)" ]; then
+        VERDICT="Claude reviewed the parser update and changed no files."
+      else
+        VERDICT="Claude reviewed the parser update and pushed a commit to this branch."
+        git commit -m "Review parser update" -m "Claude Code session: $SESSION_ID"
+        git push -u origin "$BRANCH"
+      fi
+
+      {
+        echo "## Parser update review"
+        echo
+        echo "$VERDICT"
+        echo
+        cat "$SUMMARY"
+        echo
+        echo "<sub>Claude Code session \`$SESSION_ID\`. The full transcript is in the \`claude-output.json\` artifact of the \`review-parser-update\` task.</sub>"
+      } > "$RWX_ARTIFACTS/pr-comment.md"
+
+      gh pr comment "$BRANCH" \
+        --repo rwx-cloud/language-server \
+        --body-file "$RWX_ARTIFACTS/pr-comment.md" \
+        || echo "Could not post the pull request comment. The summary is in the log above."
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_BOT_TOKEN }}
       GITHUB_TOKEN: ${{ github-apps.rwx-cloud-bot.token }}
 
   - key: check-key-descriptions
-    if: ${{ tasks.parser-update-exists.values.parser-update-exists }}
     use: npm-install
     run: npm run check-key-descriptions
     filter:

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -106,41 +106,51 @@ tasks:
       git reset --hard "origin/$BRANCH"
       git checkout -B "$BRANCH"
 
+      # The task runs with `set -e`. Keep the exit code so that the summary and
+      # the pull request comment are still written when Claude fails.
+      CLAUDE_STATUS=0
       claude \
         -p "Run the /review-parser-update skill on the current branch. Apply changes directly to the branch. I will commit and push when you are done." \
         --permission-mode auto \
         --verbose \
         --output-format json \
-        > $RWX_ARTIFACTS/claude-output.json
+        > $RWX_ARTIFACTS/claude-output.json || CLAUDE_STATUS=$?
 
       # `--output-format json` with `--verbose` emits an array of messages.
       # The final `result` message carries the summary and the session id.
       RESULT_MSG='if type == "array" then (map(select(.type == "result")) | last) else . end'
       SUMMARY="$RWX_ARTIFACTS/review-summary.md"
-      SESSION_ID="$(jq -r "$RESULT_MSG | .session_id // \"unknown\"" "$RWX_ARTIFACTS/claude-output.json" 2>/dev/null || echo "unknown")"
+      SESSION_ID="$(jq -r "$RESULT_MSG | .session_id // empty" "$RWX_ARTIFACTS/claude-output.json" 2>/dev/null || true)"
+      [ -n "$SESSION_ID" ] || SESSION_ID="unknown"
       jq -r "$RESULT_MSG | .result // empty" "$RWX_ARTIFACTS/claude-output.json" > "$SUMMARY" 2>/dev/null || true
       if [ ! -s "$SUMMARY" ]; then
-        echo "Claude returned no summary. Read the claude-output.json artifact." > "$SUMMARY"
+        echo "Claude wrote no summary. Read the claude-output.json artifact." > "$SUMMARY"
       fi
 
       echo "===== Claude review summary (session $SESSION_ID) ====="
       cat "$SUMMARY"
       echo "===== end of Claude review summary ====="
 
-      git add support/parser.d.ts src/key-descriptions.ts src/server.ts scripts/compare-parser-keys.ts
-
-      SKIPPED="$(git diff --name-only -- . ':!support/parser.js')"
-      if [ -n "$SKIPPED" ]; then
-        echo "WARNING: Claude changed files that this task does not commit:"
-        echo "$SKIPPED"
-      fi
-
-      if [ -z "$(git diff --name-only --cached)" ]; then
-        VERDICT="Claude reviewed the parser update and changed no files."
+      if [ "$CLAUDE_STATUS" -ne 0 ]; then
+        VERDICT="Claude exited with status $CLAUDE_STATUS. It did not finish the review, so this task committed nothing."
       else
-        VERDICT="Claude reviewed the parser update and pushed a commit to this branch."
-        git commit -m "Review parser update" -m "Claude Code session: $SESSION_ID"
-        git push -u origin "$BRANCH"
+        # A missing path must not stop the pull request comment. The warning
+        # below reports anything that stays unstaged.
+        git add support/parser.d.ts src/key-descriptions.ts src/server.ts scripts/compare-parser-keys.ts || true
+
+        SKIPPED="$(git diff --name-only -- . ':!support/parser.js')"
+        if [ -n "$SKIPPED" ]; then
+          echo "WARNING: Claude changed files that this task does not commit:"
+          echo "$SKIPPED"
+        fi
+
+        if [ -z "$(git diff --name-only --cached)" ]; then
+          VERDICT="Claude reviewed the parser update and changed no files."
+        else
+          VERDICT="Claude reviewed the parser update and pushed a commit to this branch."
+          git commit -m "Review parser update" -m "Claude Code session: $SESSION_ID"
+          git push -u origin "$BRANCH"
+        fi
       fi
 
       {
@@ -157,6 +167,8 @@ tasks:
         --repo rwx-cloud/language-server \
         --body-file "$RWX_ARTIFACTS/pr-comment.md" \
         || echo "Could not post the pull request comment. The summary is in the log above."
+
+      exit "$CLAUDE_STATUS"
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_BOT_TOKEN }}
       GITHUB_TOKEN: ${{ github-apps.rwx-cloud-bot.token }}

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,9 +30,11 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import * as path from "path";
 import * as fs from "fs";
+import * as YAML from "yaml";
 import {
   YamlParser,
   Leaves,
+  type LeafSpec,
   type PartialLocalPackage,
   type PartialRunDefinition,
   type PartialTaskDefinition,
@@ -435,6 +437,121 @@ async function safelyParseLocalPackage(
   }
 }
 
+// Mirrors YamlParser.safelyParseRun, but parses with the published package grammar.
+async function safelyParsePublishedPackage(
+  fileName: string,
+  source: string,
+): Promise<{
+  leafSpec: LeafSpec;
+  errors: UserMessage[];
+}> {
+  try {
+    const parser = YamlParser.createParser(fileName, source, false);
+    const leafSpec = await parser.parseLeafSpec();
+    const { errors } = parser.formatMessages();
+    return { leafSpec, errors };
+  } catch (error) {
+    if (isParsingError(error)) {
+      return {
+        leafSpec: { tasks: [], warningMessages: [], packageSchemaVersion: 2 },
+        errors: error.asMessages(),
+      };
+    }
+    throw error;
+  }
+}
+
+// A local package and a published package share the `package` marker key, so
+// only the value tells them apart: a scalar `true` against a metadata block.
+function isPublishedPackageDefinition(source: string): boolean {
+  try {
+    const doc = YAML.parseDocument(source, {
+      merge: true,
+      prettyErrors: false,
+      stringKeys: true,
+    });
+    if (!YAML.isMap(doc.contents)) {
+      return false;
+    }
+    const packageItem = doc.contents.items.find(
+      ({ key }) => YAML.isScalar(key) && key.value === "package",
+    );
+    return packageItem !== undefined && YAML.isMap(packageItem.value);
+  } catch {
+    return false;
+  }
+}
+
+type ParsedDefinition =
+  | {
+      kind: "run";
+      partialRunDefinition: PartialRunDefinition | undefined;
+      errors: UserMessage[];
+    }
+  | {
+      kind: "local-package";
+      partialLocalPackage: PartialLocalPackage;
+      errors: UserMessage[];
+    }
+  | {
+      kind: "published-package";
+      leafSpec: LeafSpec;
+      errors: UserMessage[];
+    };
+
+async function parseDefinition(
+  fileName: string,
+  source: string,
+): Promise<ParsedDefinition> {
+  if (YamlParser.isLocalPackageDefinition(source)) {
+    const { partialLocalPackage, errors } = await safelyParseLocalPackage(
+      fileName,
+      source,
+    );
+    return { kind: "local-package", partialLocalPackage, errors };
+  }
+
+  if (isPublishedPackageDefinition(source)) {
+    const { leafSpec, errors } = await safelyParsePublishedPackage(
+      fileName,
+      source,
+    );
+    return { kind: "published-package", leafSpec, errors };
+  }
+
+  const { partialRunDefinition, errors } = await YamlParser.safelyParseRun(
+    fileName,
+    source,
+  );
+  return { kind: "run", partialRunDefinition, errors };
+}
+
+function definitionTasks(
+  parsed: ParsedDefinition,
+): PartialTaskDefinition[] | undefined {
+  switch (parsed.kind) {
+    case "run":
+      return parsed.partialRunDefinition?.tasks;
+    case "local-package":
+      return parsed.partialLocalPackage.tasks;
+    case "published-package":
+      return parsed.leafSpec.tasks;
+  }
+}
+
+function definitionWarningMessages(
+  parsed: ParsedDefinition,
+): PartialRunDefinition["warningMessages"] | undefined {
+  switch (parsed.kind) {
+    case "run":
+      return parsed.partialRunDefinition?.warningMessages;
+    case "local-package":
+      return parsed.partialLocalPackage.warningMessages;
+    case "published-package":
+      return parsed.leafSpec.warningMessages;
+  }
+}
+
 async function validateTextDocumentForDiagnostics(
   textDocument: TextDocument,
 ): Promise<Diagnostic[]> {
@@ -458,23 +575,11 @@ async function validateTextDocumentForDiagnostics(
   const diagnostics: Diagnostic[] = [];
 
   try {
-    // Parse the document using the Mint parser. Files that set `package: true`
-    // are local packages and use a different grammar than run definitions.
     const fileName = textDocument.uri.replace("file://", "");
-    let errors: UserMessage[];
-    let warningMessages: PartialRunDefinition["warningMessages"] | undefined;
-    let tasks: PartialTaskDefinition[] | undefined;
-    if (YamlParser.isLocalPackageDefinition(text)) {
-      const result = await safelyParseLocalPackage(fileName, text);
-      errors = result.errors;
-      warningMessages = result.partialLocalPackage.warningMessages;
-      tasks = result.partialLocalPackage.tasks;
-    } else {
-      const result = await YamlParser.safelyParseRun(fileName, text);
-      errors = result.errors;
-      warningMessages = result.partialRunDefinition?.warningMessages;
-      tasks = result.partialRunDefinition?.tasks;
-    }
+    const parsed = await parseDefinition(fileName, text);
+    const { errors } = parsed;
+    const warningMessages = definitionWarningMessages(parsed);
+    const tasks = definitionTasks(parsed);
 
     // Convert parser errors to diagnostics
     for (const error of errors) {
@@ -1267,11 +1372,7 @@ connection.onCompletion(
           }
         }
 
-        const tasks = YamlParser.isLocalPackageDefinition(text)
-          ? (await safelyParseLocalPackage(fileName, text)).partialLocalPackage
-              .tasks
-          : (await YamlParser.safelyParseRun(fileName, text))
-              .partialRunDefinition?.tasks;
+        const tasks = definitionTasks(await parseDefinition(fileName, text));
 
         const taskKeys = extractTaskKeys(tasks);
 
@@ -2632,27 +2733,12 @@ connection.onRequest("rwx/dumpDebugData", async (params: { uri: string }) => {
     const text = document.getText();
     const fileName = document.uri.replace("file://", "");
 
-    if (YamlParser.isLocalPackageDefinition(text)) {
-      const result = await safelyParseLocalPackage(fileName, text);
-      return {
-        fileName,
-        isMintFile: true,
-        parseResult: {
-          partialLocalPackage: result.partialLocalPackage,
-          errors: result.errors,
-        },
-      };
-    }
-
-    const result = await YamlParser.safelyParseRun(fileName, text);
+    const parsed = await parseDefinition(fileName, text);
 
     return {
       fileName,
       isMintFile: true,
-      parseResult: {
-        partialRunDefinition: result.partialRunDefinition,
-        errors: result.errors,
-      },
+      parseResult: parsed,
     };
   } catch (error) {
     return {

--- a/support/parser.d.ts
+++ b/support/parser.d.ts
@@ -241,6 +241,7 @@ export interface YamlParser {
     errors: UserMessage[];
   }>;
   parseLocalPackage(): Promise<PartialLocalPackage>;
+  parseLeafSpec(): Promise<LeafSpec>;
   formatMessages(): { errors: UserMessage[] };
 }
 
@@ -616,6 +617,37 @@ export type PartialLocalPackage = {
   defaults?: unknown;
   tasks: PartialTaskDefinition[];
   warningMessages: PartialRunDefinition["warningMessages"];
+};
+
+export type LeafSpecParameter = {
+  description: string;
+  required?: boolean;
+  default?: string;
+};
+
+export type LeafSpecOutputValue = {
+  description?: string;
+  value: string;
+};
+
+export type LeafSpecOutputs = {
+  values?: Record<string, LeafSpecOutputValue>;
+  valuesFrom?: string[];
+};
+
+export type LeafSpec = {
+  name?: string;
+  version?: string;
+  description?: string;
+  sourceCodeUrl?: string;
+  issueTrackerUrl?: string;
+  visibility?: "public";
+  parameters?: Record<string, LeafSpecParameter>;
+  outputs?: LeafSpecOutputs;
+  tasks: PartialTaskDefinition[];
+  rawSource?: Source;
+  warningMessages: PartialRunDefinition["warningMessages"];
+  packageSchemaVersion: 1 | 2;
 };
 
 export const DEFAULT_AGENT_SPECIFICATION: {

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -782,4 +782,123 @@ tasks:
       );
     });
   });
+
+  describe("Published Package Files", () => {
+    const publishedPackageContent = `package:
+  visibility: public
+  name: acme/thing
+  version: 1.0.0
+  description: Does a thing
+
+tasks:
+  - key: hello
+    run: echo "Hello, World!"
+`;
+
+    it("parses files with a `package` block as published packages, not run definitions", async () => {
+      const filePath = await createTestFile(
+        testEnv.mintDir,
+        "packages/thing.yml",
+        publishedPackageContent,
+      );
+
+      const textDocument = {
+        uri: `file://${filePath}`,
+        languageId: "yaml",
+        version: 1,
+        text: publishedPackageContent,
+      };
+
+      server.sendNotification("textDocument/didOpen", { textDocument });
+
+      const result = await server.sendRequest<DocumentDiagnosticReport>(
+        "textDocument/diagnostic",
+        {
+          textDocument: { uri: textDocument.uri },
+        },
+      );
+
+      expect(result.kind).toBe("full");
+      assert("items" in result);
+      expect(result.items).toEqual([]);
+    });
+
+    it("reports published package grammar errors", async () => {
+      const invalidContent = publishedPackageContent.replace(
+        "visibility: public",
+        "visibility: private",
+      );
+
+      const filePath = await createTestFile(
+        testEnv.mintDir,
+        "packages/thing.yml",
+        invalidContent,
+      );
+
+      const textDocument = {
+        uri: `file://${filePath}`,
+        languageId: "yaml",
+        version: 1,
+        text: invalidContent,
+      };
+
+      server.sendNotification("textDocument/didOpen", { textDocument });
+
+      const result = await server.sendRequest<DocumentDiagnosticReport>(
+        "textDocument/diagnostic",
+        {
+          textDocument: { uri: textDocument.uri },
+        },
+      );
+
+      expect(result.kind).toBe("full");
+      assert("items" in result);
+      const diagnostic = result.items[0];
+      assert(diagnostic);
+      expect(diagnostic.severity).toBe(DiagnosticSeverity.Error);
+      expect(diagnostic.source).toBe("rwx-run-parser");
+      expect(diagnostic.message).toContain(
+        "Invalid package visibility `private`",
+      );
+    });
+
+    it("reports an error when a published package has no tasks", async () => {
+      const noTasksContent = `package:
+  visibility: public
+  name: acme/thing
+  version: 1.0.0
+`;
+
+      const filePath = await createTestFile(
+        testEnv.mintDir,
+        "packages/thing.yml",
+        noTasksContent,
+      );
+
+      const textDocument = {
+        uri: `file://${filePath}`,
+        languageId: "yaml",
+        version: 1,
+        text: noTasksContent,
+      };
+
+      server.sendNotification("textDocument/didOpen", { textDocument });
+
+      const result = await server.sendRequest<DocumentDiagnosticReport>(
+        "textDocument/diagnostic",
+        {
+          textDocument: { uri: textDocument.uri },
+        },
+      );
+
+      expect(result.kind).toBe("full");
+      assert("items" in result);
+      const diagnostic = result.items[0];
+      assert(diagnostic);
+      expect(diagnostic.severity).toBe(DiagnosticSeverity.Error);
+      expect(diagnostic.message).toContain(
+        "A published package must contain a `tasks` key",
+      );
+    });
+  });
 });

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -291,6 +291,42 @@ tasks:
       expect(contents.value).toContain("task definitions");
     });
 
+    it("provides hover for a published package metadata key", async () => {
+      const yamlContent = `package:
+  visibility: public
+  name: acme/thing
+
+tasks:
+  - key: build
+    run: echo hi`;
+
+      const filePath = await createTestFile(
+        testEnv.mintDir,
+        "published-package.yml",
+        yamlContent
+      );
+
+      const textDocument = {
+        uri: `file://${filePath}`,
+        languageId: "yaml",
+        version: 1,
+        text: yamlContent,
+      };
+
+      server.sendNotification("textDocument/didOpen", { textDocument });
+
+      const hover = await server.sendRequest<Hover>("textDocument/hover", {
+        textDocument: { uri: textDocument.uri },
+        position: Position.create(1, 4),
+      });
+
+      assert(hover);
+      const contents = hover.contents as MarkupContent;
+      expect(contents.kind).toBe(MarkupKind.Markdown);
+      expect(contents.value).toContain("**`visibility`**");
+      expect(contents.value).toContain("published package");
+    });
+
     it("provides hover for a task property key", async () => {
       const yamlContent = `tasks:
   - key: build


### PR DESCRIPTION
While working on #89, `check-key-descriptions` in CI failed. It gates on Claude parser updates, so it had not failed on main when we actually pulled in the changes to support local packages in #88 (because Claude opted not to add anything in that PR).

We need that check to run on every commit so that we get fast feedback on missing keys. We also need better feedback from the Claude instance that runs on branches in this repo.

Finally, we need to ensure that the language server can parse local packages.